### PR TITLE
Support previewing email files in bucket

### DIFF
--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^0.27.2",
         "core-js": "^3.8.3",
         "fflate": "^0.8.0",
+        "html-to-text": "^9.0.5",
         "pdfvuer": "^2.0.1",
         "postal-mime": "^1.0.16",
         "sweetalert2": "^11.4.8",
@@ -611,6 +612,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
+    "node_modules/@selderee/plugin-htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/@sideway/address": {
@@ -3310,7 +3337,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5157,6 +5183,98 @@
         "node": ">=12"
       }
     },
+    "node_modules/html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "dependencies": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/html-to-text/node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/html-to-text/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-to-text/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
+      }
+    },
     "node_modules/html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -5980,6 +6098,14 @@
       "dev": true,
       "dependencies": {
         "launch-editor": "^2.4.0"
+      }
+    },
+    "node_modules/leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/levn": {
@@ -7127,6 +7253,18 @@
       "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
       "dev": true
     },
+    "node_modules/parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "dependencies": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7214,6 +7352,14 @@
       "peerDependencies": {
         "pdfjs-dist": "2.5.207",
         "vue": "^3.1.0"
+      }
+    },
+    "node_modules/peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==",
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/picocolors": {
@@ -8362,6 +8508,17 @@
         "sass-embedded": {
           "optional": true
         }
+      }
+    },
+    "node_modules/selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "dependencies": {
+        "parseley": "^0.12.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/killymxi"
       }
     },
     "node_modules/select-hose": {
@@ -10815,6 +10972,25 @@
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==",
       "dev": true
     },
+    "@selderee/plugin-htmlparser2": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.11.0.tgz",
+      "integrity": "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==",
+      "requires": {
+        "domhandler": "^5.0.3",
+        "selderee": "^0.11.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        }
+      }
+    },
     "@sideway/address": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
@@ -12879,8 +13055,7 @@
     "domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-      "dev": true
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
       "version": "4.3.1",
@@ -14268,6 +14443,69 @@
         "terser": "^5.10.0"
       }
     },
+    "html-to-text": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/html-to-text/-/html-to-text-9.0.5.tgz",
+      "integrity": "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==",
+      "requires": {
+        "@selderee/plugin-htmlparser2": "^0.11.0",
+        "deepmerge": "^4.3.1",
+        "dom-serializer": "^2.0.0",
+        "htmlparser2": "^8.0.2",
+        "selderee": "^0.11.0"
+      },
+      "dependencies": {
+        "deepmerge": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+          "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+        },
+        "dom-serializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.2",
+            "entities": "^4.2.0"
+          }
+        },
+        "domhandler": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+          "requires": {
+            "domelementtype": "^2.3.0"
+          }
+        },
+        "domutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "requires": {
+            "dom-serializer": "^2.0.0",
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3"
+          }
+        },
+        "entities": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+          "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+        },
+        "htmlparser2": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+          "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+          "requires": {
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.0.1",
+            "entities": "^4.4.0"
+          }
+        }
+      }
+    },
     "html-webpack-plugin": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
@@ -14839,6 +15077,11 @@
       "requires": {
         "launch-editor": "^2.4.0"
       }
+    },
+    "leac": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/leac/-/leac-0.6.0.tgz",
+      "integrity": "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="
     },
     "levn": {
       "version": "0.4.1",
@@ -15712,6 +15955,15 @@
         }
       }
     },
+    "parseley": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/parseley/-/parseley-0.12.1.tgz",
+      "integrity": "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==",
+      "requires": {
+        "leac": "^0.6.0",
+        "peberminta": "^0.9.0"
+      }
+    },
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -15778,6 +16030,11 @@
         "raw-loader": "^0.5.1",
         "vue-resize-sensor": "^2.0.0"
       }
+    },
+    "peberminta": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/peberminta/-/peberminta-0.9.0.tgz",
+      "integrity": "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -16527,6 +16784,14 @@
       "requires": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
+      }
+    },
+    "selderee": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/selderee/-/selderee-0.11.0.tgz",
+      "integrity": "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==",
+      "requires": {
+        "parseley": "^0.12.0"
       }
     },
     "select-hose": {

--- a/packages/dashboard/package-lock.json
+++ b/packages/dashboard/package-lock.json
@@ -12,6 +12,7 @@
         "core-js": "^3.8.3",
         "fflate": "^0.8.0",
         "pdfvuer": "^2.0.1",
+        "postal-mime": "^1.0.16",
         "sweetalert2": "^11.4.8",
         "util": "^0.12.4",
         "vue": "^3.2.13",
@@ -7254,6 +7255,11 @@
       "dependencies": {
         "ms": "^2.1.1"
       }
+    },
+    "node_modules/postal-mime": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-1.0.16.tgz",
+      "integrity": "sha512-DIpZ6HfV8GIGerAOui+Q3YEE9EZNK3sdZdH2yGVhbVsB7F6bbD3L4D+W2wch7aV+aOkY5EMjMuKYbRDQGdSQBA=="
     },
     "node_modules/postcss": {
       "version": "8.4.14",
@@ -15805,6 +15811,11 @@
           }
         }
       }
+    },
+    "postal-mime": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-1.0.16.tgz",
+      "integrity": "sha512-DIpZ6HfV8GIGerAOui+Q3YEE9EZNK3sdZdH2yGVhbVsB7F6bbD3L4D+W2wch7aV+aOkY5EMjMuKYbRDQGdSQBA=="
     },
     "postcss": {
       "version": "8.4.14",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -12,6 +12,7 @@
     "core-js": "^3.8.3",
     "fflate": "^0.8.0",
     "pdfvuer": "^2.0.1",
+    "postal-mime": "^1.0.16",
     "sweetalert2": "^11.4.8",
     "util": "^0.12.4",
     "vue": "^3.2.13",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -11,6 +11,7 @@
     "axios": "^0.27.2",
     "core-js": "^3.8.3",
     "fflate": "^0.8.0",
+    "html-to-text": "^9.0.5",
     "pdfvuer": "^2.0.1",
     "postal-mime": "^1.0.16",
     "sweetalert2": "^11.4.8",

--- a/packages/dashboard/src/components/FilePreview.vue
+++ b/packages/dashboard/src/components/FilePreview.vue
@@ -64,6 +64,10 @@
           <log-gz :filedata="fileData" />
         </template>
 
+        <template v-else-if="type === 'email'">
+          <email-viewer :filedata="fileData" />
+        </template>
+
         <template v-else>
           <h4 class="text-center">Unsupported file type</h4>
         </template>
@@ -79,11 +83,13 @@ import {parseMarkdown} from '@/parsers/markdown'
 import repo from '@/api'
 import utils from '@/utils'
 import LogGz from "@/components/preview/logGz.vue";
+import EmailViewer from '@/components/preview/EmailViewer.vue'
 
 export default {
   components: {
     LogGz,
     PdfViewer,
+    EmailViewer,
     modal
   },
   data: function () {

--- a/packages/dashboard/src/components/preview/EmailViewer.vue
+++ b/packages/dashboard/src/components/preview/EmailViewer.vue
@@ -20,20 +20,22 @@
         </small>
     </div>
 
-    <br/>
 
-    <template v-if="emailData.text">
-      <div class="overflow-auto" v-html="emailData.text.replaceAll('\n', '<br>')"></div>
-    </template>
-
-    <template v-else>
-      <div class="overflow-auto">[Empty text]</div>
-    </template>
-
-    <hr/>
+    <h5 class="mb-3" v-if="!emailData.html && !emailData.text">This email has no HTML or text content</h5>
 
     <template v-if="emailData.html">
-      <h5 class="mb-3">This email contains HTML content</h5>
+      <br/>
+      <div class="overflow-auto" v-html="emailData.htmlAsText.replaceAll('\n', '<br>')"></div>
+      <hr/>
+    </template>
+
+    <template v-if="emailData.text">
+      <details :open="emailData.html ? undefined : 'open'">
+        <summary>Text</summary>
+        <br/>
+        <div class="overflow-auto" v-html="emailData.text.replaceAll('\n', '<br>')"></div>
+      </details>
+      <hr/>
     </template>
 
     <template v-if="emailData.attachments?.length > 0">
@@ -42,6 +44,7 @@
         <small class="text-muted">{{ attachment.filename }}</small>
       </div>
     </template>
+
   </template>
 
   <template v-else>
@@ -49,11 +52,12 @@
       <div class="lds-dual-ring"></div>
     </div>
   </template>
-
 </template>
+
 
 <script>
 const PostalMime = require('postal-mime');
+const { convert } = require('html-to-text');
 
 export default {
   props: ['filedata'],
@@ -69,6 +73,9 @@ export default {
         const parsedEmail = await parser.parse(this.filedata);
 
         this.emailData = parsedEmail;
+        if (parsedEmail.html) {
+          this.emailData.htmlAsText = convert(parsedEmail.html, {});
+        }
       } catch (error) {
         console.error('Error parsing email data:', error);
       }

--- a/packages/dashboard/src/components/preview/EmailViewer.vue
+++ b/packages/dashboard/src/components/preview/EmailViewer.vue
@@ -1,16 +1,55 @@
 <template>
-  <div>
-    <div v-if="emailData.sender">
-      <strong>Sender:</strong> {{ emailData.sender }}
+  <template v-if="emailData">
+
+    <h5 class="font-18">{{ emailData.subject }}</h5>
+
+    <hr/>
+
+    <div class="d-flex align-items-start mb-2 mt-1">
+      <div class="w-100">
+        <small class="float-end">{{ emailData.date }}</small>
+        <small class="text-muted">From: {{ emailData.from?.name }} &lt;{{ emailData.from?.address }}&gt;</small>
+      </div>
+      
     </div>
-    <div v-if="emailData.receiver">
-      <strong>Receiver:</strong> {{ emailData.receiver }}
+    <div class="w-100">
+        <small class="text-muted">To: 
+          <template v-for="recipient of emailData.to">
+            {{ recipient.name }} &lt;{{ recipient.address }}&gt;&semi;
+          </template>
+        </small>
     </div>
-    <div v-if="emailData.content">
-      <strong>Content:</strong>
-      <div v-html="emailData.content"></div>
+
+    <br/>
+
+    <template v-if="emailData.text">
+      <div class="overflow-auto" v-html="emailData.text.replaceAll('\n', '<br>')"></div>
+    </template>
+
+    <template v-else>
+      <div class="overflow-auto">[Empty text]</div>
+    </template>
+
+    <hr/>
+
+    <template v-if="emailData.html">
+      <h5 class="mb-3">This email contains HTML content</h5>
+    </template>
+
+    <template v-if="emailData.attachments?.length > 0">
+      <h5 class="mb-3">This email has {{ emailData.attachments.length }} attachment(s):</h5>
+      <div class="w-100" v-for="attachment of emailData.attachments" :key="attachment.filename">
+        <small class="text-muted">{{ attachment.filename }}</small>
+      </div>
+    </template>
+  </template>
+
+  <template v-else>
+    <div class="text-center">
+      <div class="lds-dual-ring"></div>
     </div>
-  </div>
+  </template>
+
 </template>
 
 <script>
@@ -27,25 +66,16 @@ export default {
     async parseEmail() {
       try {
         const parser = new PostalMime.default();
-        const parsedEmailData = await parser.parse(this.filedata);
+        const parsedEmail = await parser.parse(this.filedata);
 
-        // Extract sender, receiver, and content
-        const sender = parsedEmailData.from?.address;
-        const receiver = parsedEmailData.to?.address;
-        const content = parsedEmailData.text;
-
-        this.emailData = {
-          sender,
-          receiver,
-          content,
-        };
+        this.emailData = parsedEmail;
       } catch (error) {
         console.error('Error parsing email data:', error);
       }
     }
   },
-  mounted() {
-    this.parseEmail();
+  async mounted() {
+    await this.parseEmail();
   }
 }
 </script>

--- a/packages/dashboard/src/components/preview/EmailViewer.vue
+++ b/packages/dashboard/src/components/preview/EmailViewer.vue
@@ -1,0 +1,51 @@
+<template>
+  <div>
+    <div v-if="emailData.sender">
+      <strong>Sender:</strong> {{ emailData.sender }}
+    </div>
+    <div v-if="emailData.receiver">
+      <strong>Receiver:</strong> {{ emailData.receiver }}
+    </div>
+    <div v-if="emailData.content">
+      <strong>Content:</strong>
+      <div v-html="emailData.content"></div>
+    </div>
+  </div>
+</template>
+
+<script>
+const PostalMime = require('postal-mime');
+
+export default {
+  props: ['filedata'],
+  data: function () {
+    return {
+      emailData: null
+    }
+  },
+  methods: {
+    async parseEmail() {
+      try {
+        const parser = new PostalMime.default();
+        const parsedEmailData = await parser.parse(this.filedata);
+
+        // Extract sender, receiver, and content
+        const sender = parsedEmailData.from?.address;
+        const receiver = parsedEmailData.to?.address;
+        const content = parsedEmailData.text;
+
+        this.emailData = {
+          sender,
+          receiver,
+          content,
+        };
+      } catch (error) {
+        console.error('Error parsing email data:', error);
+      }
+    }
+  },
+  mounted() {
+    this.parseEmail();
+  }
+}
+</script>

--- a/packages/dashboard/src/preview.js
+++ b/packages/dashboard/src/preview.js
@@ -48,6 +48,11 @@ const PreviewConfigs = [
     extensions: ['log.gz'],
     type: 'logs',
     downloadType: 'blob'
+  },
+  {
+    extensions: ['eml'],
+    type: 'email',
+    downloadType: 'text'
   }
 ]
 


### PR DESCRIPTION
Aside from the email explorer, which requires the user to route emails to the explorer worker, some users may simply route or store the raw email data (`.eml` file) into their buckets. This pull request enables the preview of the email files directly from the buckets.

I borrowed many codes from `receiveEmail.ts` and `EmailDetails.vue`, but made some subjective changes:
1. All recipients will be listed in the `To` field.
2. For privacy purposes, HTML will be converted into text with no external resources loaded.
3. Attachments are not downloadable, but their names, if exist, will be listed. This can definitely be improved. I'm just not sure how to do it due to lack of front-end skills.

This is more like a PoC since I have no idea how to CSS. Please let me know if there's anything I can assist with.
