### PR TITLE
Deployment with Cloudflare Workers button (button only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ Read this in other languages: [Español](READMEes.md), [Português](READMEpt.md)
 
 ## Getting Started
 
+You can either deploy with Cloudflare Deploy Button using GitHub Actions or deploy on your own.
+
+### Deploy with Cloudflare Deploy Button
+
+[![Deploy to Cloudflare Workers](https://deploy.workers.cloudflare.com/button?paid=true)](https://deploy.workers.cloudflare.com/?url=https://github.com/G4brym/R2-Explorer&paid=true)
+
+### Deploying manually using npm and Wrangler (command line)
+
 Run this command to get an example project setup
 
 ```bash


### PR DESCRIPTION
It is proposed to enable quick deployment button using the Cloudflare Workers tool for quick deployment, it is only the button (from the readme), for it to work the secrets must be different (following the same nameclature as other cases).