### PR TITLE
Fix: Allow uppercase file extensions to be previewed

### DIFF
--- a/packages/dashboard/src/components/preview/FilePreview.vue
+++ b/packages/dashboard/src/components/preview/FilePreview.vue
@@ -221,7 +221,7 @@ export default {
 		getType(filename) {
 			for (const config of this.previewConfig) {
 				for (const extension of config.extensions) {
-					if (filename.endsWith(extension)) {
+					if (filename.toLowerCase().endsWith(extension)) {
 						return { type: config.type, downloadType: config.downloadType };
 					}
 				}


### PR DESCRIPTION
Any files which end in an uppercase extension (e.g. `.JPG` from most cameras) are currently unable to be previewed - they get rendered as text. Simply lowercasing the extension before comparing seems to be all that's needed to fix this!

It works great on a local patch that I tried