### PR TITLE
Update docs home

### DIFF
--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -1,62 +1,36 @@
 ---
-sidebar: false
-outline: false
+# https://vitepress.dev/reference/default-theme-home-page
+layout: home
+
+hero:
+  name: "R2 Explorer"
+  image: /assets/r2-explorer-logo.png
+  tagline: A Google Drive Interface for your Cloudflare R2 Buckets!
+  actions:
+    - theme: brand
+      text: Getting Started
+      link: /getting-started/creating-a-new-project.md
+    - theme: alt
+      text: Features
+      link: /#features
+
+features:
+  - title: 🔒 Secure Access Control
+    details: Implement Basic Authentication or integrate with Cloudflare Access for robust security.
+    link: /getting-started/security.md
+  - title: 📁 Flexible R2 Bucket Management
+    details: Configure and manage access to multiple R2 buckets with customizable bindings.
+    link: /getting-started/add-r2-buckets.md
+  - title: ✍️ Read/Write Operations
+    details: Enable write operations for file uploads, folder creation, and modifications (default is readonly).
+    link: /getting-started/configuration.md#disabling-readonly-mode
+  - title: 📧 Integrated Email Explorer
+    details: Receive, view, and manage emails via Cloudflare Email Routing, stored directly in R2.
+    link: /guides/setup-email-explorer.md
+  - title: ⚙️ Customizable Configuration
+    details: Tailor R2 Explorer with options for CORS, caching, and specific feature settings.
+    link: /getting-started/configuration.md
+  - title: 🚀 Easy Deployment & Updates
+    details: Deploy via GitHub Actions, CLI, or manual template, with custom domain support and update notifications.
+    link: /getting-started/deploying.md
 ---
-
-<div align="center">
-  <a href="https://r2explorer.com/">
-    <img src="/assets/r2-explorer-logo.png" width="500" height="auto" alt="R2-Explorer"/>
-  </a>
-</div>
-
-<p align="center">
-    <em>A Google Drive Interface for your Cloudflare R2 Buckets!</em>
-</p>
-
-<p align="center">
-    <a href="https://github.com/G4brym/R2-Explorer/commits/main" target="_blank">
-      <img src="https://img.shields.io/github/commit-activity/m/G4brym/R2-Explorer?label=Commits&style=social" alt="R2-Explorer Commits">
-  </a>
-    <a href="https://github.com/G4brym/R2-Explorer/issues" target="_blank">
-      <img src="https://img.shields.io/github/issues/G4brym/R2-Explorer?style=social" alt="Issues">
-  </a>
-    <a href="https://github.com/G4brym/R2-Explorer/blob/main/LICENSE" target="_blank">
-      <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=social" alt="Software License">
-  </a>
-</p>
-
-<hr />
-
-Read this in other languages: [Español](https://r2explorer-com.translate.goog/?_x_tr_sl=en&_x_tr_tl=es&_x_tr_hl=es&_x_tr_pto=wapp),
-[Português](https://r2explorer-com.translate.goog/?_x_tr_sl=en&_x_tr_tl=pt-PT&_x_tr_hl=pt-PT&_x_tr_pto=wapp),
-[Français](https://r2explorer-com.translate.goog/?_x_tr_sl=en&_x_tr_tl=fr&_x_tr_hl=fr&_x_tr_pto=wapp)
-
-## Features
-
-- **🔒 Security**
-  - Basic Authentication support
-  - Cloudflare Access integration
-  - Self-hosted on your Cloudflare account
-
-- **📁 File Management**
-  - Drag-and-drop file upload
-  - Folder creation and organization
-  - Multi-part upload for large files
-  - Right-click context menu for advanced options
-  - HTTP/Custom metadata editing
-
-- **👀 File Handling**
-  - In-browser file preview
-    - PDF documents
-    - Images
-    - Text files
-    - Markdown
-    - CSV
-    - Logpush files
-  - In-browser file editing
-  - Folder upload support
-
-- **📧 Email Integration**
-  - Receive and process emails via Cloudflare Email Routing
-  - View email attachments directly in the interface
-          - (Sending email functionality is planned for a future release)


### PR DESCRIPTION

This update tailors `packages/docs/index.md` to the Vitepress home layout, with content specifically for R2 Explorer and its documented features.

Here are the key changes I made:
- The hero section is now updated with the R2 Explorer name, logo, tagline, and relevant calls to action.
- The features section has been populated with R2 Explorer's capabilities, which I verified against the existing documentation:
    - Secure Access Control (Basic Auth, Cloudflare Access)
    - Flexible R2 Bucket Management
    - Read/Write Operations
    - Integrated Email Explorer
    - Customizable Configuration
    - Easy Deployment & Updates
- Links in the hero actions and features now point to the relevant documentation pages.

This version corrects previous iterations by ensuring all listed features are accurate and removing any that were based on incorrect assumptions (e.g., multi-language support for the app itself). The documentation's main page now accurately reflects R2 Explorer and uses the standard Vitepress home page structure.