### PR TITLE
Only show bucket picker if there are several buckets

### DIFF
--- a/packages/dashboard/src/components/main/Topbar.vue
+++ b/packages/dashboard/src/components/main/Topbar.vue
@@ -8,18 +8,23 @@
     R2-Explorer
   </q-toolbar-title>
   <q-space />
-  <div>
+  <div v-if="mainStore.buckets.length > 1">
     <bucket-picker/>
   </div>
 </template>
 
 <script>
 import BucketPicker from "components/main/BucketPicker.vue";
+import { useMainStore } from "stores/main-store";
 import { defineComponent } from "vue";
 
 export default defineComponent({
 	name: "TopBar",
 	emits: ["toggle"],
 	components: { BucketPicker },
+	setup() {
+		const mainStore = useMainStore();
+		return { mainStore };
+	},
 });
 </script>


### PR DESCRIPTION
Hey, this is just a small change to hide the bucket selector in the navbar unless there are several buckets to choose between.

Please let me know if you'd like me to make any changes! 