### PR TITLE
Fix Content-Disposition header injection in GetObject

### DIFF
--- a/.changeset/fix-content-disposition-injection.md
+++ b/.changeset/fix-content-disposition-injection.md
@@ -1,0 +1,5 @@
+---
+"r2-explorer": patch
+---
+
+Fix Content-Disposition header injection in GetObject by sanitizing filenames (replacing non-ASCII with `_` and double quotes with `'`) and adding RFC 5987 `filename*=UTF-8''...` parameter for proper Unicode support.

--- a/packages/worker/src/modules/buckets/getObject.ts
+++ b/packages/worker/src/modules/buckets/getObject.ts
@@ -57,9 +57,14 @@ export class GetObject extends OpenAPIRoute {
 		object.writeHttpMetadata(headers);
 		headers.set("etag", object.httpEtag);
 		headers.set("content-length", object.size.toString());
+
+		const fileName = filePath.split("/").pop() || "download";
+		const asciiFileName = fileName
+			.replace(/[^\x20-\x7E]/g, "_")
+			.replace(/"/g, "'");
 		headers.set(
 			"Content-Disposition",
-			`attachment; filename="${filePath.split("/").pop()}"`,
+			`attachment; filename="${asciiFileName}"; filename*=UTF-8''${encodeURIComponent(fileName)}`,
 		);
 
 		return new Response(object.body, {

--- a/packages/worker/tests/integration/object.test.ts
+++ b/packages/worker/tests/integration/object.test.ts
@@ -147,8 +147,8 @@ describe("Object Specific Endpoints", () => {
 			expect(response.headers.get("content-type")).toBe(TEST_OBJECT_CONTENT_TYPE);
 			expect(response.headers.get("content-length")).toBe(TEST_OBJECT_CONTENT.length.toString());
 			expect(response.headers.has("etag")).toBe(true);
-			// Default R2 GetObject includes Content-Disposition: attachment; filename="key"
-			expect(response.headers.get("content-disposition")).toBe(`attachment; filename="${TEST_OBJECT_KEY}"`);
+			// Default R2 GetObject includes Content-Disposition with sanitized filename and RFC 5987 filename*
+			expect(response.headers.get("content-disposition")).toBe(`attachment; filename="${TEST_OBJECT_KEY}"; filename*=UTF-8''${encodeURIComponent(TEST_OBJECT_KEY)}`);
 
 			const body = await response.text();
 			expect(body).toBe(TEST_OBJECT_CONTENT);


### PR DESCRIPTION
## Summary

- Fixes an unsanitized filename in the `Content-Disposition` header in `packages/worker/src/modules/buckets/getObject.ts`
- Filenames containing double quotes (e.g., `my "file".pdf`) could produce a malformed header like `filename="my "file".pdf"`, breaking downloads or enabling header injection
- Adds an ASCII-safe `filename` parameter (non-ASCII chars replaced with `_`, double quotes replaced with `'`) and a proper RFC 5987 `filename*=UTF-8''...` parameter with percent encoding
- This brings `GetObject` in line with `GetShareLink`, which already uses `encodeURIComponent()` for the filename

## Test plan

- [ ] Upload a file with double quotes in the name and verify it downloads correctly
- [ ] Upload a file with non-ASCII characters (e.g., `日本語.pdf`) and verify the downloaded filename is correct
- [ ] Verify normal filenames still download with the correct name

🤖 Generated with [Claude Code](https://claude.com/claude-code)