### PR TITLE
Add ShareMetadata type and fix middleware type safety

### DIFF
--- a/.changeset/add-share-metadata-type.md
+++ b/.changeset/add-share-metadata-type.md
@@ -1,0 +1,5 @@
+---
+"r2-explorer": patch
+---
+
+Add `ShareMetadata` type interface for share link metadata, replacing untyped `any` in `getShareLink` and implicit `any` in `listShares`. Also fix `readOnlyMiddleware` to use Hono's `Next` type instead of `CallableFunction`.

--- a/packages/worker/src/foundation/middlewares/readonly.ts
+++ b/packages/worker/src/foundation/middlewares/readonly.ts
@@ -1,9 +1,7 @@
+import type { Next } from "hono";
 import type { AppContext } from "../../types";
 
-export async function readOnlyMiddleware(
-	c: AppContext,
-	next: CallableFunction,
-) {
+export async function readOnlyMiddleware(c: AppContext, next: Next) {
 	const config = c.get("config");
 
 	if (config.readonly === true && !["GET", "HEAD"].includes(c.req.method)) {

--- a/packages/worker/src/modules/buckets/createShareLink.ts
+++ b/packages/worker/src/modules/buckets/createShareLink.ts
@@ -1,7 +1,7 @@
 import { OpenAPIRoute } from "chanfana";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-import type { AppContext } from "../../types";
+import type { AppContext, ShareMetadata } from "../../types";
 
 export class CreateShareLink extends OpenAPIRoute {
 	schema = {
@@ -105,7 +105,7 @@ export class CreateShareLink extends OpenAPIRoute {
 			: undefined;
 
 		// Create share metadata
-		const shareMetadata = {
+		const shareMetadata: ShareMetadata = {
 			bucket: bucketName,
 			key: key,
 			expiresAt: expiresAt,

--- a/packages/worker/src/modules/buckets/getShareLink.ts
+++ b/packages/worker/src/modules/buckets/getShareLink.ts
@@ -1,7 +1,7 @@
 import { OpenAPIRoute } from "chanfana";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-import type { AppContext } from "../../types";
+import type { AppContext, ShareMetadata } from "../../types";
 
 export class GetShareLink extends OpenAPIRoute {
 	schema = {
@@ -44,7 +44,7 @@ export class GetShareLink extends OpenAPIRoute {
 		const shareId = data.params.shareId;
 
 		// Search all buckets for the share metadata
-		let shareMetadata: any = null;
+		let shareMetadata: ShareMetadata | null = null;
 		let bucket: R2Bucket | null = null;
 
 		for (const key in c.env) {
@@ -60,7 +60,7 @@ export class GetShareLink extends OpenAPIRoute {
 			);
 
 			if (shareObject) {
-				shareMetadata = JSON.parse(await shareObject.text());
+				shareMetadata = JSON.parse(await shareObject.text()) as ShareMetadata;
 				bucket = currentBucket;
 				break;
 			}

--- a/packages/worker/src/modules/buckets/listShares.ts
+++ b/packages/worker/src/modules/buckets/listShares.ts
@@ -1,7 +1,7 @@
 import { OpenAPIRoute } from "chanfana";
 import { HTTPException } from "hono/http-exception";
 import { z } from "zod";
-import type { AppContext } from "../../types";
+import type { AppContext, ShareMetadata } from "../../types";
 
 export class ListShares extends OpenAPIRoute {
 	schema = {
@@ -70,7 +70,7 @@ export class ListShares extends OpenAPIRoute {
 			const shareObject = await bucket.get(obj.key);
 			if (!shareObject) continue;
 
-			const metadata = JSON.parse(await shareObject.text());
+			const metadata = JSON.parse(await shareObject.text()) as ShareMetadata;
 
 			// Check if expired
 			const isExpired = !!(metadata.expiresAt && now > metadata.expiresAt);

--- a/packages/worker/src/types.d.ts
+++ b/packages/worker/src/types.d.ts
@@ -25,6 +25,17 @@ export type R2ExplorerConfig = {
 	buckets?: Record<string, BucketConfig>;
 };
 
+export type ShareMetadata = {
+	bucket: string;
+	key: string;
+	expiresAt?: number;
+	passwordHash?: string;
+	maxDownloads?: number;
+	currentDownloads: number;
+	createdBy: string;
+	createdAt: number;
+};
+
 export type AppEnv = {
 	ASSETS: Fetcher;
 	[key: string]: R2Bucket;


### PR DESCRIPTION
## Summary

- Adds a `ShareMetadata` type interface to `types.d.ts` that defines the structure of share link metadata stored in R2
- Replaces the untyped `any` in `getShareLink.ts` with the new `ShareMetadata` type, improving type safety when accessing share metadata properties (`expiresAt`, `maxDownloads`, `passwordHash`, etc.)
- Types the parsed JSON in `listShares.ts` with `ShareMetadata` for consistent typing across share link modules
- Types the metadata object in `createShareLink.ts` to ensure it conforms to the `ShareMetadata` interface at creation time
- Fixes `readOnlyMiddleware` to use Hono's `Next` type instead of `CallableFunction`, which is the correct type for Hono middleware

## Why

The share link metadata was being created with a well-defined structure in `createShareLink.ts`, but consumed as `any` in `getShareLink.ts` and implicitly untyped in `listShares.ts`. This meant there was no compile-time checking that the code accessing metadata properties (like `expiresAt`, `passwordHash`, `currentDownloads`) was correct. The new `ShareMetadata` type provides a single source of truth for the metadata shape.

## Test plan

- [x] All existing tests pass (82 passed, 7 skipped — same as before)
- [x] `pnpm lint` passes with no issues
- [x] `tsc` type checking passes
- [x] No behavior changes — this is a type-only refactor