### PR TITLE
feat: add file and folder duplicate/copy operation

### DIFF
--- a/.changeset/add-duplicate-copy-operation.md
+++ b/.changeset/add-duplicate-copy-operation.md
@@ -1,0 +1,5 @@
+---
+"r2-explorer": minor
+---
+
+Add file and folder duplicate/copy operation via context menu. Right-clicking a file or folder and selecting "Duplicate" creates a copy with a " (copy)" suffix in the same directory, preserving all metadata.

--- a/packages/dashboard/e2e/file-operations.spec.ts
+++ b/packages/dashboard/e2e/file-operations.spec.ts
@@ -109,6 +109,33 @@ test.describe("File operations", () => {
 		});
 	});
 
+	test.describe("Duplicate file", () => {
+		test.beforeEach(async ({ request }) => {
+			await uploadFile(request, "e2e-copy-source.txt", "duplicate me");
+		});
+
+		test.afterEach(async ({ request }) => {
+			await deleteObject(request, "e2e-copy-source.txt");
+			await deleteObject(request, "e2e-copy-source (copy).txt");
+		});
+
+		test("duplicates a file via context menu", async ({ page }) => {
+			await page.goto(`/${BUCKET}/files`);
+			await expect(page.locator("text=e2e-copy-source.txt")).toBeVisible({
+				timeout: 10_000,
+			});
+
+			await page.locator("text=e2e-copy-source.txt").click({ button: "right" });
+			await page.locator(".q-menu").getByText("Duplicate").click();
+
+			// Copy should appear in listing, original should still be there
+			await expect(page.locator("text=e2e-copy-source (copy).txt")).toBeVisible({
+				timeout: 5_000,
+			});
+			await expect(page.locator("text=e2e-copy-source.txt").first()).toBeVisible();
+		});
+	});
+
 	test.describe("Delete folder", () => {
 		test.beforeEach(async ({ request }) => {
 			await createFolder(request, "e2e-delete-folder");

--- a/packages/dashboard/src/appUtils.js
+++ b/packages/dashboard/src/appUtils.js
@@ -171,6 +171,12 @@ export const apiHandler = {
 			newKey: encode(newKey),
 		});
 	},
+	copyObject: (bucket, sourceKey, destinationKey) => {
+		return api.post(`/buckets/${bucket}/copy`, {
+			sourceKey: encode(sourceKey),
+			destinationKey: encode(destinationKey),
+		});
+	},
 	updateMetadata: async (bucket, key, customMetadata, httpMetadata = {}) => {
 		let prefix = "";
 		if (key.includes("/")) {

--- a/packages/dashboard/src/components/files/FileOptions.vue
+++ b/packages/dashboard/src/components/files/FileOptions.vue
@@ -128,6 +128,74 @@ export default defineComponent({
 				);
 			}
 		},
+		generateCopyName: (key, isFolder) => {
+			if (isFolder) {
+				const base = key.replace(/\/$/, "");
+				return `${base} (copy)/`;
+			}
+			const lastDot = key.lastIndexOf(".");
+			const lastSlash = key.lastIndexOf("/");
+			if (lastDot > lastSlash + 1) {
+				return `${key.substring(0, lastDot)} (copy)${key.substring(lastDot)}`;
+			}
+			return `${key} (copy)`;
+		},
+		duplicateObject: async function (row) {
+			if (row.type === "folder") {
+				const folderContents = await apiHandler.fetchFile(
+					this.selectedBucket,
+					row.key,
+					"",
+				);
+
+				const sourcePrefix = row.key;
+				const destPrefix = this.generateCopyName(sourcePrefix, true);
+
+				const notif = this.q.notify({
+					group: false,
+					spinner: true,
+					message: "Duplicating folder...",
+					caption: "0%",
+					timeout: 0,
+				});
+
+				await apiHandler.createFolder(destPrefix, this.selectedBucket);
+
+				for (const [i, innerFile] of folderContents.entries()) {
+					if (innerFile.key && !innerFile.key.endsWith("/")) {
+						const newKey = innerFile.key.replace(sourcePrefix, destPrefix);
+						await apiHandler.copyObject(
+							this.selectedBucket,
+							innerFile.key,
+							newKey,
+						);
+					}
+					notif({
+						caption: `${Number.parseInt((i * 100) / folderContents.length)}%`,
+					});
+				}
+
+				notif({
+					icon: "done",
+					spinner: false,
+					caption: "100%",
+					message: "Folder duplicated!",
+					timeout: 2500,
+				});
+			} else {
+				const destKey = this.generateCopyName(row.key, false);
+				await apiHandler.copyObject(this.selectedBucket, row.key, destKey);
+				this.q.notify({
+					group: false,
+					icon: "done",
+					spinner: false,
+					message: "File duplicated!",
+					timeout: 2500,
+				});
+			}
+
+			this.$bus.emit("fetchFiles");
+		},
 		renameConfirm: async function () {
 			if (this.renameInput.length === 0) {
 				return;

--- a/packages/dashboard/src/pages/files/FileContextMenu.vue
+++ b/packages/dashboard/src/pages/files/FileContextMenu.vue
@@ -9,6 +9,9 @@
     <q-item clickable v-close-popup @click="renameObject" v-if="prop.row.type === 'file'">
       <q-item-section>Rename</q-item-section>
     </q-item>
+    <q-item clickable v-close-popup @click="duplicateObject">
+      <q-item-section>Duplicate</q-item-section>
+    </q-item>
     <q-item clickable v-close-popup @click="updateMetadataObject" v-if="prop.row.type === 'file'">
       <q-item-section>Update Metadata</q-item-section>
     </q-item>
@@ -70,6 +73,9 @@ export default {
 	methods: {
 		renameObject: function () {
 			this.$emit("renameObject", this.prop.row);
+		},
+		duplicateObject: function () {
+			this.$emit("duplicateObject", this.prop.row);
 		},
 		updateMetadataObject: function () {
 			this.$emit("updateMetadataObject", this.prop.row);

--- a/packages/dashboard/src/pages/files/FilesFolderPage.vue
+++ b/packages/dashboard/src/pages/files/FilesFolderPage.vue
@@ -81,7 +81,7 @@
               touch-position
               context-menu
             >
-              <FileContextMenu :prop="prop" @openObject="openObject" @deleteObject="$refs.options.deleteObject" @renameObject="$refs.options.renameObject" @updateMetadataObject="$refs.options.updateMetadataObject" @createShareLink="$refs.shareFile.openCreateShare" />
+              <FileContextMenu :prop="prop" @openObject="openObject" @deleteObject="$refs.options.deleteObject" @renameObject="$refs.options.renameObject" @duplicateObject="$refs.options.duplicateObject" @updateMetadataObject="$refs.options.updateMetadataObject" @createShareLink="$refs.shareFile.openCreateShare" />
             </q-menu>
           </template>
 
@@ -89,7 +89,7 @@
             <td class="text-right">
               <q-btn round flat icon="more_vert" size="sm">
                 <q-menu>
-                  <FileContextMenu :prop="prop" @openObject="openObject" @deleteObject="$refs.options.deleteObject" @renameObject="$refs.options.renameObject" @updateMetadataObject="$refs.options.updateMetadataObject" @createShareLink="$refs.shareFile.openCreateShare" />
+                  <FileContextMenu :prop="prop" @openObject="openObject" @deleteObject="$refs.options.deleteObject" @renameObject="$refs.options.renameObject" @duplicateObject="$refs.options.duplicateObject" @updateMetadataObject="$refs.options.updateMetadataObject" @createShareLink="$refs.shareFile.openCreateShare" />
                 </q-menu>
               </q-btn>
             </td>

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -10,6 +10,7 @@ import { cors } from "hono/cors";
 import { z } from "zod";
 import { readOnlyMiddleware } from "./foundation/middlewares/readonly";
 import { settings } from "./foundation/settings";
+import { CopyObject } from "./modules/buckets/copyObject";
 import { CreateFolder } from "./modules/buckets/createFolder";
 import { CreateShareLink } from "./modules/buckets/createShareLink";
 import { DeleteObject } from "./modules/buckets/deleteObject";
@@ -121,6 +122,7 @@ export function R2Explorer(config?: R2ExplorerConfig) {
 
 	openapi.get("/api/buckets/:bucket", ListObjects);
 	openapi.post("/api/buckets/:bucket/move", MoveObject);
+	openapi.post("/api/buckets/:bucket/copy", CopyObject);
 	openapi.post("/api/buckets/:bucket/folder", CreateFolder);
 	openapi.post("/api/buckets/:bucket/upload", PutObject);
 	openapi.post("/api/buckets/:bucket/multipart/create", CreateUpload);

--- a/packages/worker/src/modules/buckets/copyObject.ts
+++ b/packages/worker/src/modules/buckets/copyObject.ts
@@ -1,0 +1,62 @@
+import { OpenAPIRoute } from "chanfana";
+import { HTTPException } from "hono/http-exception";
+import { z } from "zod";
+import type { AppContext } from "../../types";
+
+export class CopyObject extends OpenAPIRoute {
+	schema = {
+		operationId: "post-bucket-copy-object",
+		tags: ["Buckets"],
+		summary: "Copy object",
+		request: {
+			params: z.object({
+				bucket: z.string(),
+			}),
+			body: {
+				content: {
+					"application/json": {
+						schema: z.object({
+							sourceKey: z.string().describe("base64 encoded source file key"),
+							destinationKey: z
+								.string()
+								.describe("base64 encoded destination file key"),
+						}),
+					},
+				},
+			},
+		},
+	};
+
+	async handle(c: AppContext) {
+		const data = await this.getValidatedData<typeof this.schema>();
+
+		const bucketName = data.params.bucket;
+		const bucket = c.env[bucketName] as R2Bucket | undefined;
+
+		if (!bucket) {
+			throw new HTTPException(500, {
+				message: `Bucket binding not found: ${bucketName}`,
+			});
+		}
+
+		const sourceKey = decodeURIComponent(escape(atob(data.body.sourceKey)));
+		const destinationKey = decodeURIComponent(
+			escape(atob(data.body.destinationKey)),
+		);
+
+		const object = await bucket.get(sourceKey);
+
+		if (object === null) {
+			throw new HTTPException(404, {
+				message: `Source object not found: ${sourceKey}`,
+			});
+		}
+
+		const resp = await bucket.put(destinationKey, object.body, {
+			customMetadata: object.customMetadata,
+			httpMetadata: object.httpMetadata,
+		});
+
+		return resp;
+	}
+}

--- a/packages/worker/tests/integration/copy.test.ts
+++ b/packages/worker/tests/integration/copy.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createTestApp, createTestRequest } from "./setup";
+import { env, createExecutionContext } from "cloudflare:test";
+
+describe("CopyObject (POST /api/buckets/:bucket/copy)", () => {
+	let app: ReturnType<typeof createTestApp>;
+	let MY_TEST_BUCKET_1: R2Bucket;
+	const BUCKET_NAME = "MY_TEST_BUCKET_1";
+	const SOURCE_KEY = "test-source.txt";
+	const SOURCE_CONTENT = "Hello R2 Explorer!";
+	const SOURCE_CONTENT_TYPE = "text/plain";
+
+	beforeEach(async () => {
+		app = createTestApp();
+		MY_TEST_BUCKET_1 = env.MY_TEST_BUCKET_1;
+
+		if (MY_TEST_BUCKET_1) {
+			const listed = await MY_TEST_BUCKET_1.list();
+			const keysToDelete = listed.objects.map((obj) => obj.key);
+			if (keysToDelete.length > 0) {
+				await MY_TEST_BUCKET_1.delete(keysToDelete);
+			}
+			await MY_TEST_BUCKET_1.put(SOURCE_KEY, SOURCE_CONTENT, {
+				httpMetadata: { contentType: SOURCE_CONTENT_TYPE },
+				customMetadata: { project: "r2-explorer", version: "1.0" },
+			});
+		}
+	});
+
+	afterEach(async () => {
+		if (MY_TEST_BUCKET_1) {
+			const listed = await MY_TEST_BUCKET_1.list();
+			const keysToDelete = listed.objects.map((obj) => obj.key);
+			if (keysToDelete.length > 0) {
+				await MY_TEST_BUCKET_1.delete(keysToDelete);
+			}
+		}
+	});
+
+	it("should copy an existing file to a new destination", async () => {
+		const destKey = "test-source (copy).txt";
+		const request = createTestRequest(
+			`/api/buckets/${BUCKET_NAME}/copy`,
+			"POST",
+			{
+				sourceKey: btoa(SOURCE_KEY),
+				destinationKey: btoa(destKey),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(200);
+		await response.text();
+
+		// Verify copy exists
+		const copyObj = await MY_TEST_BUCKET_1.get(destKey);
+		expect(copyObj).not.toBeNull();
+		const copyContent = await copyObj!.text();
+		expect(copyContent).toBe(SOURCE_CONTENT);
+
+		// Verify original still exists
+		const sourceObj = await MY_TEST_BUCKET_1.get(SOURCE_KEY);
+		expect(sourceObj).not.toBeNull();
+		const sourceContent = await sourceObj!.text();
+		expect(sourceContent).toBe(SOURCE_CONTENT);
+	});
+
+	it("should preserve custom metadata on the copy", async () => {
+		const destKey = "test-source (copy).txt";
+		const request = createTestRequest(
+			`/api/buckets/${BUCKET_NAME}/copy`,
+			"POST",
+			{
+				sourceKey: btoa(SOURCE_KEY),
+				destinationKey: btoa(destKey),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(200);
+		await response.text();
+
+		const copyHead = await MY_TEST_BUCKET_1.head(destKey);
+		expect(copyHead).not.toBeNull();
+		expect(copyHead?.customMetadata).toEqual({
+			project: "r2-explorer",
+			version: "1.0",
+		});
+	});
+
+	it("should preserve HTTP metadata on the copy", async () => {
+		const destKey = "test-source (copy).txt";
+		const request = createTestRequest(
+			`/api/buckets/${BUCKET_NAME}/copy`,
+			"POST",
+			{
+				sourceKey: btoa(SOURCE_KEY),
+				destinationKey: btoa(destKey),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(200);
+		await response.text();
+
+		const copyHead = await MY_TEST_BUCKET_1.head(destKey);
+		expect(copyHead).not.toBeNull();
+		expect(copyHead?.httpMetadata?.contentType).toBe(SOURCE_CONTENT_TYPE);
+	});
+
+	it("should return 404 when source object does not exist", async () => {
+		const request = createTestRequest(
+			`/api/buckets/${BUCKET_NAME}/copy`,
+			"POST",
+			{
+				sourceKey: btoa("non-existent.txt"),
+				destinationKey: btoa("copy.txt"),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(404);
+		const body = await response.text();
+		expect(body).toContain("Source object not found");
+	});
+
+	it("should return 500 when bucket binding does not exist", async () => {
+		const request = createTestRequest(
+			"/api/buckets/NON_EXISTENT_BUCKET/copy",
+			"POST",
+			{
+				sourceKey: btoa(SOURCE_KEY),
+				destinationKey: btoa("copy.txt"),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(500);
+		const body = await response.text();
+		expect(body).toContain("Bucket binding not found: NON_EXISTENT_BUCKET");
+	});
+
+	it("should not delete the source object after copy", async () => {
+		const destKey = "test-source (copy).txt";
+		const request = createTestRequest(
+			`/api/buckets/${BUCKET_NAME}/copy`,
+			"POST",
+			{
+				sourceKey: btoa(SOURCE_KEY),
+				destinationKey: btoa(destKey),
+			},
+			{ "Content-Type": "application/json" },
+		);
+		const response = await app.fetch(request, env, createExecutionContext());
+		expect(response.status).toBe(200);
+		await response.text();
+
+		// Verify both source and destination exist
+		const sourceObj = await MY_TEST_BUCKET_1.head(SOURCE_KEY);
+		expect(sourceObj).not.toBeNull();
+
+		const destObj = await MY_TEST_BUCKET_1.head(destKey);
+		expect(destObj).not.toBeNull();
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a "Duplicate" option to the file/folder context menu that creates a copy with a " (copy)" suffix, preserving all metadata
- New `CopyObject` backend endpoint (`POST /api/buckets/:bucket/copy`) that gets the source object and puts it at the destination without deleting the original
- Frontend handles both single file duplication (instant) and folder duplication (iterates contents with progress indicator)

## Related Issue
Prodboard issue: bcb8905b3911e595 — [I] [R2-Explorer] Add file and folder duplicate/copy operation

## Changes
- **New file**: `packages/worker/src/modules/buckets/copyObject.ts` — CopyObject endpoint following MoveObject pattern (without delete)
- **Modified**: `packages/worker/src/index.ts` — Register `/api/buckets/:bucket/copy` route
- **Modified**: `packages/dashboard/src/appUtils.js` — Add `copyObject` API handler method
- **Modified**: `packages/dashboard/src/pages/files/FileContextMenu.vue` — Add "Duplicate" menu item
- **Modified**: `packages/dashboard/src/components/files/FileOptions.vue` — Add `duplicateObject` and `generateCopyName` methods
- **Modified**: `packages/dashboard/src/pages/files/FilesFolderPage.vue` — Wire up `duplicateObject` event
- **New file**: `packages/worker/tests/integration/copy.test.ts` — 6 backend integration tests
- **Modified**: `packages/dashboard/e2e/file-operations.spec.ts` — E2E test for file duplication via context menu

## Test Plan
- [x] All 88 worker integration tests pass (including 6 new copy tests)
- [x] All 110 dashboard component tests pass
- [x] Lint passes cleanly
- [ ] E2E tests for file duplication via context menu
- [ ] Manual test: right-click file → Duplicate → verify copy appears with " (copy)" suffix
- [ ] Manual test: right-click folder → Duplicate → verify folder and contents are copied
- [ ] Verify readonly mode blocks the copy endpoint (POST is blocked by readonly middleware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)